### PR TITLE
fix link readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ module.exports = {
 ## Querying Twitter Users
 
 Once the plugin is configured, the `allTwitterUser` query will be available to you
-you can test it in your [GraphiQL Debugger](https:localhost:8000/___graphql)
+you can test it in your GraphiQL Debugger: `https://localhost:8000/___graphql`
 
 ## Note
 

--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ module.exports = {
 ## Querying Twitter Users
 
 Once the plugin is configured, the `allTwitterUser` query will be available to you
-you can test it in your GraphiQL Debugger: `https://localhost:8000/___graphql`
+you can test it in your GraphiQL Debugger: `http://localhost:8000/___graphql`
 
 ## Note
 


### PR DESCRIPTION
as the readme is published as https://www.gatsbyjs.org/packages/gatsby-source-twitter-users/

i add this fixes:
- as gatsby guidelines suggest to put localhost into code fences
- fix the link with missing `//`
- local link not have `https` - only `http`



